### PR TITLE
E2144. Refactor delayed_mailer.rb and scheduled_task.rb

### DIFF
--- a/app/mailers/drop_outstanding_reviews_mail_worker.rb
+++ b/app/mailers/drop_outstanding_reviews_mail_worker.rb
@@ -1,0 +1,38 @@
+class DropOutstandingReviewsMailWorker < MailWorker
+  @@deadline_type = "drop_outstanding_reviews"
+
+  def perform(assignment_id, due_at)
+    super(assignment_id, @@deadline_type, due_at)
+  end
+
+  protected
+
+  def prepare_data
+    drop_outstanding_reviews
+    drop_one_member_topics if assignment.team_assignment
+  end
+
+  private
+
+  def drop_outstanding_reviews
+    reviews = ResponseMap.where(reviewed_object_id: @assignment.id)
+    reviews.each do |review|
+      review_has_began = Response.where(map_id: review.id)
+      if review_has_began.size.zero?
+        review_to_drop = ResponseMap.where(id: review.id)
+        review_to_drop.first.destroy
+      end
+    end
+  end
+
+  def drop_one_member_topics
+    teams = TeamsUser.all.group(:team_id).count(:team_id)
+    teams.keys.each do |team_id|
+      if teams[team_id] == 1
+        topic_to_drop = SignedUpTeam.where(team_id: team_id).first
+        topic_to_drop.delete if topic_to_drop # check if the one-person-team has signed up a topic
+      end
+    end
+  end
+
+end

--- a/app/mailers/mail_worker.rb
+++ b/app/mailers/mail_worker.rb
@@ -5,38 +5,36 @@ class MailWorker
   # ActionMailer in Rail 4 submits jobs in mailers queue instead of default queue. Rails 5 and onwards
   # ActionMailer will submit mailer jobs to default queue. We need to remove the line below in that case!
   sidekiq_options queue: 'mailers'
-  attr_accessor :assignment_id
+  attr_accessor :assignment
   attr_accessor :deadline_type
+  attr_accessor :deadline_text
   attr_accessor :due_at
 
   def perform(assignment_id, deadline_type, due_at)
-    self.assignment_id = assignment_id
+    self.assignment_id = Assignment.find(assignment_id)
     self.deadline_type = deadline_type
+    self.deadline_text = deadline_type
     self.due_at = due_at
 
-    assignment = Assignment.find(self.assignment_id)
-    participant_mails = find_participant_emails
+    participant_emails = find_participant_emails
 
-    if %w[drop_one_member_topics drop_outstanding_reviews compare_files_with_simicheck].include?(self.deadline_type)
-      drop_one_member_topics if self.deadline_type == "drop_outstanding_reviews" && assignment.team_assignment
-      drop_outstanding_reviews if self.deadline_type == "drop_outstanding_reviews"
-      perform_simicheck_comparisons(self.assignment_id) if self.deadline_type == "compare_files_with_simicheck"
-    else
-      # Can we rename deadline_type(metareview) to "teammate review". If, yes then we donot need this if clause below!
-      deadlineText = if self.deadline_type == "metareview"
-                       "teammate review"
-                     else
-                       self.deadline_type
-      end
+    prepare_data
 
-      email_reminder(participant_mails, deadlineText) unless participant_mails.empty?
-    end
+    email_reminder(participant_emails, self.deadline_text) unless participant_emails.empty?
   end
 
+  protected
+
+  def prepare_data
+    # Can we rename deadline_type(metareview) to "teammate review". If, yes then we do not need this if clause below!
+    self.deadline_text = self.deadline_type == "metareview" ? "teammate review" : self.deadline_type
+  end
+
+  private
+
   def email_reminder(emails, deadline_type)
-    assignment = Assignment.find(self.assignment_id)
-    subject = "Message regarding #{deadline_type} for assignment #{assignment.name}"
-    body = "This is a reminder to complete #{deadline_type} for assignment #{assignment.name}. \
+    subject = "Message regarding #{deadline_type} for assignment #{self.assignment.name}"
+    body = "This is a reminder to complete #{deadline_type} for assignment #{self.assignment.name}. \
     Deadline is #{self.due_at}.If you have already done the  #{deadline_type}, Please ignore this mail."
 
     emails.each do |mail|
@@ -56,28 +54,4 @@ class MailWorker
     emails
   end
 
-  def drop_one_member_topics
-    teams = TeamsUser.all.group(:team_id).count(:team_id)
-    teams.keys.each do |team_id|
-      if teams[team_id] == 1
-        topic_to_drop = SignedUpTeam.where(team_id: team_id).first
-        topic_to_drop.delete if topic_to_drop # check if the one-person-team has signed up a topic
-      end
-    end
-  end
-
-  def drop_outstanding_reviews
-    reviews = ResponseMap.where(reviewed_object_id: self.assignment_id)
-    reviews.each do |review|
-      review_has_began = Response.where(map_id: review.id)
-      if review_has_began.size.zero?
-        review_to_drop = ResponseMap.where(id: review.id)
-        review_to_drop.first.destroy
-      end
-    end
-  end
-
-  def perform_simicheck_comparisons(assignment_id)
-    PlagiarismCheckerHelper.run(assignment_id)
-  end
 end

--- a/app/mailers/simicheck_mail_worker.rb
+++ b/app/mailers/simicheck_mail_worker.rb
@@ -1,0 +1,19 @@
+class SimicheckMailWorker < MailWorker
+  @@deadline_type = "compare_files_with_simicheck"
+
+  def perform(assignment_id, due_at)
+    super(assignment_id, @@deadline_type, due_at)
+  end
+
+  protected
+
+  def prepare_data
+    perform_simicheck_comparisons
+  end
+
+  private
+
+  def perform_simicheck_comparisons()
+    PlagiarismCheckerHelper.run(@assignment.id)
+  end
+end

--- a/app/models/due_date.rb
+++ b/app/models/due_date.rb
@@ -1,3 +1,5 @@
+require 'active_support/time_with_zone'
+
 class DueDate < ActiveRecord::Base
   validate :due_at_is_valid_datetime
   #  has_paper_trail
@@ -110,5 +112,36 @@ class DueDate < ActiveRecord::Base
       next_due_date = AssignmentDueDate.find_by(['parent_id = ? && due_at >= ?', assignment_id, Time.zone.now])
     end
     next_due_date
+  end
+
+  def self.get_time_diff_btw_due_date_and_now(due_date)
+    due_date_time = to_time(due_date)
+    time_left_in_minutes_duration = find_min_from_now_duration(due_date_time)
+    diff_btw_time_left_and_threshold_minutes_duration = time_left_in_minutes_duration - due_date.threshold.hour.in_minutes
+    [diff_btw_time_left_and_threshold_minutes_duration, time_left_in_minutes_duration]
+  end
+
+  def self.get_dequeue_time_as_seconds_duration_from_now(due_date, delay_duration)
+    due_date_time = to_time(due_date)
+    delay_seconds = delay_duration.to_i # ActiveSupport::Duration::to_i returns the duration in seconds
+    dequeue_time = due_date_time + delay_seconds
+    find_seconds_from_now_duration(dequeue_time)
+  end
+
+  private
+
+  def self.find_min_from_now_duration(due_at_time)
+    find_seconds_from_now_duration(due_at_time).in_minutes
+  end
+
+  def self.find_seconds_from_now_duration(due_at_time)
+    current_datetime = DateTime.now.in_time_zone(zone = 'UTC').to_s(:db)
+    current_time = Time.parse(current_datetime)
+
+    (due_at_time - current_time).second
+  end
+
+  def self.to_time(due_date)
+    Time.parse(due_date.due_at.to_s(:db))
   end
 end

--- a/spec/models/assignment_form_spec.rb
+++ b/spec/models/assignment_form_spec.rb
@@ -551,7 +551,7 @@ describe AssignmentForm do
   describe '#add_to_delayed_queue' do
     before(:each) do
       allow(AssignmentDueDate).to receive(:where).with(parent_id: 1).and_return([due_date])
-      allow_any_instance_of(AssignmentForm).to receive(:find_min_from_now).with(any_args).and_return(666)
+      allow_any_instance_of(AssignmentForm).to receive(:find_min_from_now_duration).with(any_args).and_return(666)
       allow(due_date).to receive(:update_attribute).with(:delayed_job_id, any_args).and_return('Succeed!')
       Sidekiq::Testing.inline!
     end
@@ -648,7 +648,7 @@ describe AssignmentForm do
     it 'returns the difference between current time and due date in minutes' do
       allow(DateTime).to receive(:now).and_return(DateTime.new(2017, 10, 7, 11, 11, 11).in_time_zone)
       due_at = Time.parse(DateTime.new(2017, 10, 7, 12, 12, 12).in_time_zone.to_s(:db))
-      expect(assignment_form.find_min_from_now(due_at)).to eq(61)
+      expect(assignment_form.find_min_from_now_duration(due_at)).to eq(61)
     end
   end
 


### PR DESCRIPTION
Resolves #9

Get rid of the conditional processing based on `deadline_type` by using the Open-Closed Principle.

- I changed MailWorker to be a default parent class, and then created two new subclasses to handle tasks that required specific processing.
- I then updated the callers of MailWorker to use the subclasses where appropriate.
